### PR TITLE
Swapping labels and values for better readability

### DIFF
--- a/app/views/pets/_stats.html.haml
+++ b/app/views/pets/_stats.html.haml
@@ -1,21 +1,21 @@
 .card-stats
   %ul
     %li
-      = pet.breed.capitalize
       %span Raza
+      = pet.breed.capitalize
     - if pet.age?
       %li
-        = pet.enum_to_s :age
         %span Edad
+        = pet.enum_to_s :age
     - if pet.sex
       %li
-        = pet.enum_to_s :sex
         %span Sexo
+        = pet.enum_to_s :sex
     - if pet.size?
       %li
-        = pet.enum_to_s :size
         %span Tamaño
+        = pet.enum_to_s :size
     - if pet.location?
       %li
-        = pet.location
         %span Lugar
+        = pet.location


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1577810/4303729/d78ec654-3e69-11e4-81d0-fe2e09e2483f.png)

I think it was confusing to read "Pontier Raza, Hembra Sexo, Lugo Lugar".
I guess it was put that way because that's how [Refills](http://refills.bourbon.io/#er-toc-id-8)' example looks (and it makes sense there, as it is used to show quantities).

Now it looks like this:

![image](https://cloud.githubusercontent.com/assets/1577810/4303689/7afaa6c4-3e69-11e4-955c-41c2c51bea9f.png)

I hope you all agree with this change. If not, we can fight to the death.
